### PR TITLE
fix: add missing types in code-size functions

### DIFF
--- a/src/event_parsing/payload_size.rs
+++ b/src/event_parsing/payload_size.rs
@@ -139,6 +139,7 @@ impl PayloadType {
             | Self::ME
             | Self::MF
             | Self::MG
+            | Self::MH
             | Self::MU
             | Self::MV
             | Self::MW
@@ -180,6 +181,7 @@ impl PayloadType {
             | Self::ME
             | Self::MF
             | Self::MG
+            | Self::MH
             | Self::MU
             | Self::MV
             | Self::MW


### PR DESCRIPTION
Problem:
`PayloadType::MH` is missing from functions
  - `master_code_size`
  - `index_length`

Solution:
Handle `PayloadType::MH` in these functions.

Remarks:
`PayloadType::MH` was added in commit 1dddc1fdf5bf.